### PR TITLE
[BUGFIX] Make sure that possibly no-longer existing array key is accessed.

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -110,7 +110,9 @@
 );
 
 $GLOBALS['TCA']['tt_content']['ctrl']['useColumnsForDefaultValues'] .= ',tx_gridelements_container,tx_gridelements_columns';
-$GLOBALS['TCA']['tt_content']['ctrl']['shadowColumnsForNewPlaceholders'] .= ',tx_gridelements_container,tx_gridelements_columns';
+if (array_key_exists('shadowColumnsForNewPlaceholders', $GLOBALS['TCA']['tt_content']['ctrl'])) {
+    $GLOBALS['TCA']['tt_content']['ctrl']['shadowColumnsForNewPlaceholders'] .= ',tx_gridelements_container,tx_gridelements_columns';
+}
 $GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes']['gridelements_pi1'] = 'gridelements-default';
 
 $GLOBALS['TCA']['tt_content']['columns']['colPos']['config']['itemsProcFunc'] = 'GridElementsTeam\Gridelements\Backend\ItemsProcFuncs\ColPosList->itemsProcFunc';


### PR DESCRIPTION
The TCA property 'shadowColumnsForNewPlaceholders' was removed in TYPO3 11, thus the line should no longer be executed in TYPO3 11 (it emits an E_WARNING error). Because this version should also be compatible to TYPO3 10, the access to the property needs to be conditional.

Reference: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.0/Breaking-92791-NewPlaceholderRecordsRemovedInWorkspaces.html