### PR TITLE
[BUGFIX] fix error: attempt to insert record on page '[root-level]' (0)

### DIFF
--- a/Classes/Xclass/RecordListController.php
+++ b/Classes/Xclass/RecordListController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace GridElementsTeam\Gridelements\Xclass;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Script Class for the Web > List module; rendering the listing of records on a page
+ * Add custom JavaScript for gridelements
+ */
+class RecordListController extends \TYPO3\CMS\Recordlist\Controller\RecordListController
+{
+
+    /**
+     * Injects the request object for the current request or subrequest
+     *
+     * @param ServerRequestInterface $request the current request
+     * @return ResponseInterface the response with the content
+     */
+    public function mainAction(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->pageRenderer->loadRequireJsModule('TYPO3/CMS/Gridelements/GridElementsOnReady');
+        return parent::mainAction($request);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -9,6 +9,8 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1488914437] = [
     'priority' => 50,
     'class' => \GridElementsTeam\Gridelements\Wizard\GridelementsBackendLayoutWizardElement::class,
 ];
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/db_layout.php']['drawHeaderHook']['gridelements'] =
+    \GridElementsTeam\Gridelements\Hooks\PageRenderer::class . '->renderPageLayout';
 
 // XCLASS
 if ($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['gridelements']['nestingInListModule']) {
@@ -18,6 +20,9 @@ if ($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['gridelements']['nestingInListModu
 if (!$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['gridelements']['fluidBasedPageModule']) {
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['fluidBasedPageModule'] = false;
 }
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Recordlist\Controller\RecordListController::class] = [
+    'className' => \GridElementsTeam\Gridelements\Xclass\RecordListController::class
+];
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addUserTSConfig('
 	options.saveDocNew.tx_gridelements_backend_layout=1

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -7,8 +7,6 @@ if (!defined('TYPO3_MODE')) {
 if (TYPO3_MODE === 'BE') {
     include_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('gridelements') . 'Classes/Backend/TtContent.php');
 
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-preProcess'][] = 'GridElementsTeam\\Gridelements\\Hooks\\PageRenderer->addJSCSS';
-
     $GLOBALS['TBE_STYLES']['skins']['gridelements']['name'] = 'gridelements';
     $GLOBALS['TBE_STYLES']['skins']['gridelements']['stylesheetDirectories']['gridelements_structure'] = 'EXT:gridelements/Resources/Public/Backend/Css/Skin/';
 


### PR DESCRIPTION
When using Drag&Drop in the page module, an error message is displayed: Attempt to insert record on page '[root-level]' (0) 
The page id is not submitted in the XHR-Request (/typo3/ajax/record/process?...), when a content element is moved into a grid element.
This happens, because the backend JavaScript is not included any more in TYPO3 11.5
In \GridElementsTeam\Gridelements\Hooks\PageRenderer::addJSCSS the current controller is determined with `$GLOBALS['SOBE']`, which does not exist any more (https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.0/Breaking-92132-LastRemainsOfGlobalsSOBERemoved.html).

This bugfix removes the usage of `$GLOBALS['SOBE']` by moving the inclusion of the backend assets for the PageLayoutController to the hook `$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/db_layout.php']['drawHeaderHook']`

Since there is no hook available for the RecordListController, the assets for this controller are added through an XClass.