### PR TITLE
Fix PHP Warning: Undefined array key "page"

### DIFF
--- a/Classes/Hooks/DrawItem.php
+++ b/Classes/Hooks/DrawItem.php
@@ -115,7 +115,9 @@ class DrawItem implements PageLayoutViewDrawItemHookInterface, SingletonInterfac
     public function cleanupCollapsedStatesInUC()
     {
         $backendUser = $this->getBackendUser();
-        if (is_array($backendUser->uc['moduleData']['page']['gridelementsCollapsedColumns'])) {
+        if (isset($backendUser->uc['moduleData']['page']['gridelementsCollapsedColumns']) 
+	    && is_array($backendUser->uc['moduleData']['page']['gridelementsCollapsedColumns'])
+	) {
             $collapsedGridelementColumns = $backendUser->uc['moduleData']['page']['gridelementsCollapsedColumns'];
             foreach ($collapsedGridelementColumns as $item => $collapsed) {
                 if (empty($collapsed)) {


### PR DESCRIPTION
Fixes the PHP warning:

Core: Error handler (BE): PHP Warning: Undefined array key "page" in /var/www/public/typo3conf/ext/gridelements/Classes/Hooks/DrawItem.php line 118