### PR TITLE
[BUGFIX] Cast tx_gridelements_container as int when calling checkForAllowedLanguages

### DIFF
--- a/Classes/Backend/ItemsProcFuncs/SysLanguageUidList.php
+++ b/Classes/Backend/ItemsProcFuncs/SysLanguageUidList.php
@@ -38,8 +38,9 @@ class SysLanguageUidList extends AbstractItemsProcFunc
      */
     public function itemsProcFunc(array &$params)
     {
-        if ((int)$params['row']['pid'] > 0 && (int)$params['row']['tx_gridelements_container'] > 0 && isset($params['items'])) {
-            $this->checkForAllowedLanguages($params['items'], (int)$params['row']['tx_gridelements_container']);
+        $container = (int)($params['row']['tx_gridelements_container'] ?? 0);
+        if (!empty($params['row']['pid']) && $params['row']['pid'] > 0 && $container > 0 && isset($params['items'])) {
+            $this->checkForAllowedLanguages($params['items'], $container);
         }
     }
 

--- a/Classes/Backend/ItemsProcFuncs/SysLanguageUidList.php
+++ b/Classes/Backend/ItemsProcFuncs/SysLanguageUidList.php
@@ -39,7 +39,7 @@ class SysLanguageUidList extends AbstractItemsProcFunc
     public function itemsProcFunc(array &$params)
     {
         if ((int)$params['row']['pid'] > 0 && (int)$params['row']['tx_gridelements_container'] > 0 && isset($params['items'])) {
-            $this->checkForAllowedLanguages($params['items'], $params['row']['tx_gridelements_container']);
+            $this->checkForAllowedLanguages($params['items'], (int)$params['row']['tx_gridelements_container']);
         }
     }
 


### PR DESCRIPTION
This fixes the error when trying to insert elements in the first position of a gridelement:
`Argument 2 passed to GridElementsTeam\Gridelements\Backend\ItemsProcFuncs\SysLanguageUidList::checkForAllowedLanguages() must be of the type int, string given, called in typo3conf/ext/gridelements/Classes/Backend/ItemsProcFuncs/SysLanguageUidList.php on line 42`