### PR TITLE
[BUGFIX] add missing headline for modal window for new content element

### DIFF
--- a/Resources/Private/Backend/Gridelements/Partials/PageLayout/Record.html
+++ b/Resources/Private/Backend/Gridelements/Partials/PageLayout/Record.html
@@ -21,7 +21,7 @@
     </div>
     <f:if condition="{allowEditContent} && {item.column.contentEditable} && {item.column.context.allowNewContent}">
         <div class="t3js-page-new-ce t3js-page-new-ce-allowed t3-page-ce-wrapper-new-ce" id="colpos-{item.column.columnNumber}-page-{item.context.pageId}-{item.column.uniqueId}">
-            <a href="{item.newContentAfterUrlWithRestrictions}" title="{item.newContentAfterLinkTitle}" data-title="{item.newContentAfterLinkTitle}"
+            <a href="{item.newContentAfterUrlWithRestrictions}" title="{newContentTitle}" data-title="{newContentTitle}"
                 class="btn btn-default btn-sm {f:if(condition:item.column.context.drawingConfiguration.showNewContentWizard, then: 't3js-toggle-new-content-element-wizard disabled')}">
                 <core:icon identifier="actions-add" />
                 {newContentTitleShort}


### PR DESCRIPTION
For some inner elements the headline is missing for the modal window. This uses the same title as the core.