### PR TITLE
[BUGFIX] getter returns wrong variable in GridelementsGridColumn

### DIFF
--- a/Classes/View/BackendLayout/Grid/GridelementsGridColumn.php
+++ b/Classes/View/BackendLayout/Grid/GridelementsGridColumn.php
@@ -240,7 +240,7 @@ class GridelementsGridColumn extends GridColumn
      */
     public function getAllowedGridType(): ?string
     {
-        return $this->disallowedGridType;
+        return $this->allowedGridType;
     }
 
     /**


### PR DESCRIPTION
getAllowedGridType should return the allowedGridType and not the disallowed