### PR TITLE
[BUGFIX] Adjust grid variable

### DIFF
--- a/Resources/Public/JavaScript/GridElementsDragDrop.js
+++ b/Resources/Public/JavaScript/GridElementsDragDrop.js
@@ -146,7 +146,7 @@ define(['jquery', 'jquery-ui/droppable', 'TYPO3/CMS/Backend/LayoutModule/DragDro
                     (!disallowedListType || ($.inArray('*', disallowedListType) === -1 && $.inArray(listType, disallowedListType) === -1))
                 )) && (gridType === '' || (
                     (!allowedGridType || $.inArray('*', allowedGridType) > -1 || $.inArray(gridType, allowedGridType) > -1) &&
-                    (!disallowedGridType || ($.inArray('*', disallowedGridType) === -1 && $.inArray(listType, disallowedGridType) === -1))
+                    (!disallowedGridType || ($.inArray('*', disallowedGridType) === -1 && $.inArray(gridType, disallowedGridType) === -1))
                 ))
                 &&
                 (


### PR DESCRIPTION
The wrong variable is used to check if grid type is disallowed.
This resulted in the "disallowed grids" feature to be ignored while dragging content elements, effectively allowing the editor to place disallowed items where they should not belong.