### PR TITLE
[BUGFIX] Remove negative uid check

### DIFF
--- a/Classes/DataHandler/AbstractDataHandler.php
+++ b/Classes/DataHandler/AbstractDataHandler.php
@@ -81,7 +81,7 @@ abstract class AbstractDataHandler
     public function init(string $table, string $uidPid, DataHandler $dataHandler)
     {
         $this->setTable($table);
-        if ($table === 'tt_content' && (int)$uidPid < 0) {
+        if ($table === 'tt_content') {
             $this->setContentUid(abs((int)$uidPid));
             $pageUid = Helper::getInstance()->getPidFromUid($this->getContentUid());
             $this->setPageUid($pageUid);


### PR DESCRIPTION
# Issue

When editing a Grid Element, and changing the layout to a layout with different columns, ContentElements inside old columns should be moved to `-2` (`(Not assigned)`).
This happens in `AfterDatabaseOperations::setUnusedElements` (based on `AbstractDataHandler`). This method relies on `$this->getContentUid()` to know which Grid Element to check. But `setContentUid` is called only when the `tt_content.uid` is negative.

As far as I can tell, this is not (always) the case when existing CE are being edited. I am not sure why we would need such a check in that context.

The commit in which the change was made (https://github.com/CodersCare/gridelements/commit/29230a621beb681f82afaac3d4d5d9076f006c9b) isn't mentioning why the check was introduced.

# How to test (before/after)

1. Create two layouts, one with one column and a second one with two
2. Create one GridElement with two columns, and add a ContentElement in each column
3. Edit the GridElement and change its layout to the single-column one
   * Before changes: no alert, the ContentElement simply isn't displayed in the backend anymore
   * After changes:
      * TYPO3 reports `Unused elements detected on this page`
      * Scrolling down to `(Not assigned)`, the ContentElement is displayed with an orange header