### PR TITLE
[BUGFIX] Translate column names in list module

### DIFF
--- a/Classes/Xclass/DatabaseRecordList.php
+++ b/Classes/Xclass/DatabaseRecordList.php
@@ -830,7 +830,7 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
                                 <td colspan="' . (count($this->fieldArray) - $level - 2 + $this->maxDepth) . '" style="padding:5px;">
                                 <br>
                                     <strong>' . $this->getLanguageService()->sL('LLL:EXT:gridelements/Resources/Private/Language/locallang_db.xlf:list.containerColumnName')
-                            . ' ' . $theData['_CONTAINER_COLUMNS_']['columns'][(int)$child['tx_gridelements_columns']] . '</strong>
+                            . ' ' . $this->getLanguageService()->sL($theData['_CONTAINER_COLUMNS_']['columns'][(int)$child['tx_gridelements_columns']]) . '</strong>
                                 </td>
                             </tr>';
                 } else {

--- a/Classes/Xclass/DatabaseRecordList10.php
+++ b/Classes/Xclass/DatabaseRecordList10.php
@@ -925,7 +925,7 @@ class DatabaseRecordList10 extends \TYPO3\CMS\Recordlist\RecordList\DatabaseReco
                                 <td colspan="' . (count($this->fieldArray) - $level - 2 + $this->maxDepth) . '" style="padding:5px;">
                                 <br>
                                     <strong>' . $this->getLanguageService()->sL('LLL:EXT:gridelements/Resources/Private/Language/locallang_db.xlf:list.containerColumnName')
-                            . ' ' . $theData['_CONTAINER_COLUMNS_']['columns'][(int)$child['tx_gridelements_columns']] . '</strong>
+                            . ' ' . $this->getLanguageService()->sL($theData['_CONTAINER_COLUMNS_']['columns'][(int)$child['tx_gridelements_columns']]) . '</strong>
                                 </td>
                             </tr>';
                 } else {


### PR DESCRIPTION
When viewing a grid in the page module, columns named with a valid translation string will display the corresponding translated value (done in the [ColumnHeader template](https://github.com/CodersCare/gridelements/blob/11-0/Resources/Private/Backend/Gridelements/Partials/PageLayout/Grid/ColumnHeader.html#L33)).
The same logic was missing in the list module, and the ll-labels were displayed instead.

This is now fixed by calling the LanguageService before outputting the column name in the list module for more consistency.