### PR TITLE
[BUGFIX] Use colspan with fluid in page module

### DIFF
--- a/Resources/Private/Backend/Gridelements/Partials/PageLayout/Grid.html
+++ b/Resources/Private/Backend/Gridelements/Partials/PageLayout/Grid.html
@@ -11,6 +11,7 @@
         </f:then>
     </f:if>
     <table border="0" cellspacing="0" cellpadding="0" width="100%" class="t3-page-columns t3-grid-table t3js-page-columns">
+        <f:render partial="PageLayout/Grid/Colgroup" arguments="{colCount: gridElementsBackendLayout.config.colCount}" />
         <f:for each="{grid.rows}" as="row">
             <tr>
                 <f:for each="{row.columns}" as="column">

--- a/Resources/Private/Backend/Gridelements/Partials/PageLayout/Grid/Colgroup.html
+++ b/Resources/Private/Backend/Gridelements/Partials/PageLayout/Grid/Colgroup.html
@@ -1,0 +1,5 @@
+<f:if condition="{colCount > 1}">
+<colgroup>
+    <f:render partial="PageLayout/Grid/ColgroupCol" arguments="{colCount: colCount, iteration: 1}" />
+</colgroup>
+</f:if>

--- a/Resources/Private/Backend/Gridelements/Partials/PageLayout/Grid/ColgroupCol.html
+++ b/Resources/Private/Backend/Gridelements/Partials/PageLayout/Grid/ColgroupCol.html
@@ -1,0 +1,5 @@
+<col style="width: {100 / colCount}%" />
+<f:if condition="{iteration} < {colCount}">
+    <f:variable name="updated_iteration">{iteration + 1}</f:variable>
+    <f:render partial="PageLayout/Grid/ColgroupCol" arguments="{colCount: colCount, iteration: updated_iteration}" />
+</f:if>


### PR DESCRIPTION
Fixes https://github.com/CodersCare/gridelements/issues/53

I didn't find a better option than calling the ColgroupCol partial recursively until we reach the target `colCount`. I'm not entirely sure why fluid doesn't natively offer a `while` ViewHelper, and [the `for` one](https://docs.typo3.org/other/typo3/view-helper-reference/11.5/en-us/typo3fluid/fluid/latest/For.html) is actually closer to a `foreach` in php (it expects an array as parameter). 

If you think of any better way to implement it, let me know! :smiley: 