### PR TITLE
[BUGFIX] only include records with the correct language in backend preview

### DIFF
--- a/Classes/PageLayoutView/GridelementsPreviewRenderer.php
+++ b/Classes/PageLayoutView/GridelementsPreviewRenderer.php
@@ -180,7 +180,8 @@ class GridelementsPreviewRenderer extends StandardContentPreviewRenderer impleme
             $children = $helper->getChildren('tt_content', $gridContainerId, $pageId, 'sorting', 0, '*');
             $childColumns = [];
             foreach ($children as $childRecord) {
-                if (isset($childRecord['tx_gridelements_columns'])) {
+                if ($childRecord['sys_language_uid'] === $context->getSiteLanguage()->getLanguageId()
+                    && isset($childRecord['tx_gridelements_columns'])) {
                     $childColumns[$childRecord['tx_gridelements_columns']][] = $childRecord;
                 }
             }


### PR DESCRIPTION
Typo3-Version: 11.5.30
Gridelements-Version: 11.1.0

I have encountered an interesting problem when copying records between grid-elements on different sites. 

In this case there is a site that supports German and French (language_ids 0 and 2 respectively) and another site that supports German and English (language_ids 0 and 1 respectively). A translated record was copied from the German-French site to the German-English site which results in the "web"-Module crashing in the backend.

The reason for the crash is that the `GridelementsPreviewRenderer.php::renderGridContainer()` function uses `Helper::getChildren()` to fetch all children of a Gridelement regardless of their language. Because the French version was copied as well there is now a Record in this children array that has a sys_language_uid field that should not exist on this page. When not in a Gridelement Context typo3 just ignores these records. 

The partial `Resources/Private/Backend/Gridelements/Partials/PageLayout/Record/Header.html` later tries to resolve `{item.siteLanguage.flagIdentifier}` which results in a LogicException being thrown because the current page does not support the language with, in this case, 2.

I don't know if the Helper Class should just respect the current language. This fix instead just filters any record that does not match the currently selected language from the childRecord array, so it is ignored in the preview.