### PR TITLE
[BUGFIX] Fix translations in deletion modals

### DIFF
--- a/Resources/Private/Backend/Gridelements/Partials/PageLayout/Record/Header.html
+++ b/Resources/Private/Backend/Gridelements/Partials/PageLayout/Record/Header.html
@@ -21,10 +21,10 @@
                         <f:if condition="{item.delible}">
                             <a class="btn btn-default t3js-modal-trigger" href="{item.deleteUrl}"
                             data-severity="warning"
-                            data-title="{item.deleteConfirmText}"
-                            data-content="{item.deleteConfirmText}"
-                            data-button-close-text="{item.deleteCancelText}"
-                            title="{item.deleteTitle}">
+                            data-title="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_alt_doc.xlf:label.confirm.delete_record.title')}"
+                            data-content="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_alt_doc.xlf:label.confirm.delete_record.content')}"
+                            data-button-close-text="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_alt_doc.xlf:buttons.confirm.delete_record.no')}"
+                            title="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_alt_doc.xlf:deleteItem')}">
                                 <core:icon identifier="actions-edit-delete" size="small" />
                             </a>
                         </f:if>

--- a/Resources/Private/Backend/PageModule/Partials/PageLayout/Record/Header.html
+++ b/Resources/Private/Backend/PageModule/Partials/PageLayout/Record/Header.html
@@ -21,10 +21,10 @@
                         <f:if condition="{item.delible}">
                             <a class="btn btn-default t3js-modal-trigger" href="{item.deleteUrl}"
                             data-severity="warning"
-                            data-title="{item.deleteConfirmText}"
-                            data-content="{item.deleteConfirmText}"
-                            data-button-close-text="{item.deleteCancelText}"
-                            title="{item.deleteTitle}">
+                            data-title="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_alt_doc.xlf:label.confirm.delete_record.title')}"
+                            data-content="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_alt_doc.xlf:label.confirm.delete_record.content')}"
+                            data-button-close-text="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_alt_doc.xlf:buttons.confirm.delete_record.no')}"
+                            title="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_alt_doc.xlf:deleteItem')}">
                                 <core:icon identifier="actions-edit-delete" size="small" />
                             </a>
                         </f:if>

--- a/Resources/Private/Backend/PageModule/Partials/PageLayout/RecordDefault/Header.html
+++ b/Resources/Private/Backend/PageModule/Partials/PageLayout/RecordDefault/Header.html
@@ -21,10 +21,10 @@
                         <f:if condition="{item.delible}">
                             <a class="btn btn-default t3js-modal-trigger" href="{item.deleteUrl}"
                             data-severity="warning"
-                            data-title="{item.deleteConfirmText}"
-                            data-content="{item.deleteConfirmText}"
-                            data-button-close-text="{item.deleteCancelText}"
-                            title="{item.deleteTitle}">
+                            data-title="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_alt_doc.xlf:label.confirm.delete_record.title')}"
+                            data-content="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_alt_doc.xlf:label.confirm.delete_record.content')}"
+                            data-button-close-text="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_alt_doc.xlf:buttons.confirm.delete_record.no')}"
+                            title="{f:translate(key: 'LLL:EXT:backend/Resources/Private/Language/locallang_alt_doc.xlf:deleteItem')}">
                                 <core:icon identifier="actions-edit-delete" size="small" />
                             </a>
                         </f:if>


### PR DESCRIPTION
When deleting a contentElement in the page module (TYPO3 `11.5.32`, GridElements `11.1.0`), the confirmation modal doesn't respect the language settings of the user. It is also very unspecific, and doesn't explicitly confirm for deletion (and simply asks "Alert: are you sure?")

| German | English |
| ------ | ------- |
| ![image](https://github.com/CodersCare/gridelements/assets/1093360/1e326547-ac21-4bf2-aec2-a4315076c684) | ![image](https://github.com/CodersCare/gridelements/assets/1093360/457832ff-4f1a-4c5c-9830-5a7de222d291) |

This seems to be caused by the `Header.html` templates, which tries to read a non-existing (or empty) property and falls back to TYPO3 JS defaults in english:

```html
<a class="btn btn-default t3js-modal-trigger" href="{item.deleteUrl}"
  data-severity="warning"
  data-title="{item.deleteConfirmText}"
  data-content="{item.deleteConfirmText}"
  data-button-close-text="{item.deleteCancelText}"
  title="{item.deleteTitle}">
```
> :information_source: See the fallback chain in the [Modal TypeScript](https://github.com/TYPO3/typo3/blob/11.5/Build/Sources/TypeScript/backend/Resources/Public/TypeScript/Modal.ts#L379):
> ```js
> const content = $element.data('bs-content') || $element.data('content') || 'Are you sure?';
> ```

I couldn't find anywhere, where `deleteConfirmText`, `deleteTitle` or `deleteCancelText` was being set (in both the GridElements extension and in the TYPO3 core), so I assume it was a copy/paste error, or it was an experiment which wasn't implemented until the end.

After fetching the translations from the `backend` extension, this is how it looks like:

| German | English |
| ------ | ------- |
| ![image](https://github.com/CodersCare/gridelements/assets/1093360/60613e4d-6e71-4212-8267-d14f0da55d3f) | ![image](https://github.com/CodersCare/gridelements/assets/1093360/66047784-d7de-4cc5-8bc1-0629279c563d) |

:information_source: the title and the content are twice the same in German, but this is due to the two strings `label.confirm.delete_record.title` and `label.confirm.delete_record.content` being identical in that locale. 