### PR TITLE
Localize text which is displayed in model dialog

### DIFF
--- a/Resources/Private/Backend/PageModule/Partials/PageLayout/RecordDefault/Header.html
+++ b/Resources/Private/Backend/PageModule/Partials/PageLayout/RecordDefault/Header.html
@@ -18,11 +18,14 @@
                                 <core:icon identifier="actions-edit-{item.visibilityToggleIconName}" />
                             </a>
                         </f:if>
+
                         <f:if condition="{item.delible}">
                             <a class="btn btn-default t3js-modal-trigger" href="{item.deleteUrl}"
                             data-severity="warning"
-                            data-title="{item.deleteConfirmText}"
-                            data-content="{item.deleteConfirmText}"
+                            data-title=""
+                            data-titleold="{item.deleteConfirmText}"
+                            data-content="{item.deleteMessage}"
+                            data-contentold="{item.deleteConfirmText}"
                             data-button-close-text="{item.deleteCancelText}"
                             title="{item.deleteTitle}">
                                 <core:icon identifier="actions-edit-delete" size="small" />


### PR DESCRIPTION
Make sure the text which is displayed in the modal dialog when warning about deleting ce with references is localized.

This reuses some code from TYPO3 v11 which is not yet available in TYPO3 v10 and was introduced in patch https://review.typo3.org/c/Packages/TYPO3.CMS/+/80116

Resolves: #45