### PR TITLE
[TASK] Add scheduler task to fix orphans

### DIFF
--- a/Classes/Task/GridelementsOrphanedChildFixer.php
+++ b/Classes/Task/GridelementsOrphanedChildFixer.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GridElementsTeam\Gridelements\Task;
+
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Scheduler\Task\AbstractTask;
+
+class GridelementsOrphanedChildFixer extends AbstractTask
+{
+
+    /**
+     * Fixes Gridelements child records which refer to a container
+     * which is no longer a gridelement. Can happen if the CType
+     * of the gridelements container is changed while children
+     * still exist.
+     *
+     * The reference is removed by setting tx_gridelements_container
+     * to 0 and colpos to the value of colpos of the formerly
+     * gridelement container CE.
+     *
+     * Additionally, the existing CEs will be set to not visible
+     * (hidden=1) because they will previously invisible and will
+     * now suddenly reapper.
+     *
+     * @return bool TRUE if task run was successful
+     */
+    public function execute(): bool
+    {
+        // it is not possible to use UPDATE together with JOIN in QueryBuilder
+        // so we use SELECT and UPDATE seperately though it is less efficient
+        $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
+        $queryBuilder = $connectionPool
+            ->getQueryBuilderForTable('tt_content');
+        $queryBuilder->getRestrictions()
+            ->removeAll()
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+        $rows = $queryBuilder
+            ->select('tt_content.uid AS uid', 't2.colpos AS colpos')
+            ->from('tt_content')
+            ->join('tt_content', 'tt_content', 't2',
+                $queryBuilder->expr()->eq('tt_content.tx_gridelements_container',
+                    $queryBuilder->quoteIdentifier('t2.uid')
+                )
+            )
+            ->where(
+                $queryBuilder->expr()->gt(
+                    'tt_content.tx_gridelements_container',
+                    0
+                ),
+                $queryBuilder->expr()->eq(
+                    'tt_content.colpos',
+                    -1
+                ),
+                $queryBuilder->expr()->neq(
+                    't2.CType',
+                    $queryBuilder->createNamedParameter('gridelements_pi1')
+                )
+            )
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        foreach ($rows as $row) {
+            $uid = (int)($row['uid']);
+
+            $connection = $connectionPool
+                ->getConnectionForTable('tt_content');
+            $connection->update(
+                'tt_content',
+                [
+                    'colpos' => (int)($row['colpos'] ?? 0),
+                    'tx_gridelements_container' => 0,
+                    'hidden' => 1,
+                ],
+                [
+                    'uid' => $uid,
+                ],
+                [
+                    Connection::PARAM_INT,
+                    Connection::PARAM_INT,
+                    Connection::PARAM_INT,
+                    Connection::PARAM_INT,
+                ]
+            );
+        }
+
+        return true;
+    }
+
+}

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -37,6 +37,12 @@
 			<trans-unit id="gridelementsNumberOfChildrenFixer.description" xml:space="preserve">
 				<source>Recalculates the value of tx_gridelements_children due to buggy container update behaviour of Cut/Copy/Paste and/or Drag/Drop methods.</source>
 			</trans-unit>
+			<trans-unit id="gridelementsOrphanedChildFixer.name" xml:space="preserve">
+				<source>Gridelements Orphaned Children Fixer</source>
+			</trans-unit>
+			<trans-unit id="ggridelementsOrphanedChildFixer.description" xml:space="preserve">
+				<source>Fixes content elements which are a child of a content element which is no longer a gridelement. These elemens will then be displayed in BE again, but are hidden.</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -56,3 +56,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][\GridElementsTea
     'description'      => 'LLL:EXT:gridelements/Resources/Private/Language/locallang.xlf:gridelementsNumberOfChildrenFixer.description'
 ];
 
+// Add orphaned children fixer task
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][\GridElementsTeam\Gridelements\Task\GridelementsOrphanedChildFixer::class] = [
+    'extension'        => 'gridelements',
+    'title'            => 'LLL:EXT:gridelements/Resources/Private/Language/locallang.xlf:gridelementsOrphanedChildFixer.name',
+    'description'      => 'LLL:EXT:gridelements/Resources/Private/Language/locallang.xlf:gridelementsOrphanedChildFixer.description'
+];
+


### PR DESCRIPTION
If the CType of a gridelement is changed to a non-gridelement, existing children will be orphaned. They still exist in the database, but are not visible in the backend list or page view.

This can now be fixed via a scheduler task:
The connection between the (formerly) gridelements container and child is severed by setting tx_gridelements_container to 0 and setting the colpos to the value of the formerly gridelements parent.

Related: #58