### PR TITLE
[BUGFIX] Call `getWorkspaceVersionOfRecord()` on TYPO3 >= v11 (#22)

### DIFF
--- a/Classes/DataHandler/AfterDatabaseOperations.php
+++ b/Classes/DataHandler/AfterDatabaseOperations.php
@@ -29,6 +29,7 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -53,7 +54,12 @@ class AfterDatabaseOperations extends AbstractDataHandler
             $originalRecord = $parentObj->recordInfo('tt_content', $uid, '*');
             if ($originalRecord['t3ver_state'] === 4) {
                 $updateArray = [];
-                $movePlaceholder = BackendUtility::getMovePlaceholder('tt_content', $uid, 'uid', $workspace);
+                $versionInformation = GeneralUtility::makeInstance(Typo3Version::class);
+                if ($versionInformation->getMajorVersion() < 11) {
+                    $movePlaceholder = BackendUtility::getMovePlaceholder('tt_content', $uid, 'uid', $workspace);
+                } else {
+                    $movePlaceholder = BackendUtility::getWorkspaceVersionOfRecord($workspace, 'tt_content', $uid, 'uid');
+                }
                 if (isset($fieldArray['colPos'])) {
                     $updateArray['colPos'] = (int)$fieldArray['colPos'];
                 }

--- a/Classes/Hooks/DrawItem.php
+++ b/Classes/Hooks/DrawItem.php
@@ -46,6 +46,7 @@ use TYPO3\CMS\Core\Database\QueryGenerator;
 use TYPO3\CMS\Core\Exception;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageQueue;
@@ -347,12 +348,22 @@ class DrawItem implements PageLayoutViewDrawItemHookInterface, SingletonInterfac
                 if ($item['t3ver_state'] === 3) {
                     $moveUids[] = (int)$item['t3ver_move_id'];
                     $item = BackendUtility::getRecordWSOL('tt_content', (int)$item['uid']);
-                    $movePlaceholder = BackendUtility::getMovePlaceholder(
-                        'tt_content',
-                        (int)$item['uid'],
-                        '*',
-                        $workspace
-                    );
+                    $versionInformation = GeneralUtility::makeInstance(Typo3Version::class);
+                    if ($versionInformation->getMajorVersion() < 11) {
+                        $movePlaceholder = BackendUtility::getMovePlaceholder(
+                            'tt_content',
+                            (int)$item['uid'],
+                            '*',
+                            $workspace
+                        );
+                    } else {
+                        $movePlaceholder = BackendUtility::getWorkspaceVersionOfRecord(
+                            $workspace,
+                            'tt_content',
+                            (int)$item['uid'],
+                            '*'
+                        );
+                    }
                     if (!empty($movePlaceholder)) {
                         $item['sorting'] = $movePlaceholder['sorting'];
                         $item['tx_gridelements_columns'] = $movePlaceholder['tx_gridelements_columns'];
@@ -361,12 +372,23 @@ class DrawItem implements PageLayoutViewDrawItemHookInterface, SingletonInterfac
                 } else {
                     $item = BackendUtility::getRecordWSOL('tt_content', (int)$item['uid']);
                     if ($item['t3ver_state'] === 4) {
-                        $movePlaceholder = BackendUtility::getMovePlaceholder(
-                            'tt_content',
-                            (int)$item['uid'],
-                            '*',
-                            $workspace
-                        );
+                        $versionInformation = GeneralUtility::makeInstance(Typo3Version::class);
+                        if ($versionInformation->getMajorVersion() < 11) {
+                            $movePlaceholder = BackendUtility::getMovePlaceholder(
+                                'tt_content',
+                                (int)$item['uid'],
+                                '*',
+                                $workspace
+                            );
+                        } else {
+                            $movePlaceholder = BackendUtility::getWorkspaceVersionOfRecord(
+                                $workspace,
+                                'tt_content',
+                                (int)$item['uid'],
+                                '*'
+                            );
+
+                        }
                         if (!empty($movePlaceholder)) {
                             $item['sorting'] = $movePlaceholder['sorting'];
                             $item['tx_gridelements_columns'] = $movePlaceholder['tx_gridelements_columns'];


### PR DESCRIPTION
This fix will invoke `getWorkspaceVersionOfRecord()` instead of `getMovePlaceholder()` on TYPO3 version 11 and above.

I couldn't find any official deprecation information or migration information from TYPO3. To resolve this I followed the code updates from Flux (https://github.com/FluidTYPO3/flux/commit/94a832aad86391c1f88fa08583016e5573a94b16).