### PR TITLE
[BUGFIX] don't use $GLOBALS["TSFE"]

### DIFF
--- a/Classes/Backend/LayoutSetup.php
+++ b/Classes/Backend/LayoutSetup.php
@@ -126,7 +126,7 @@ class LayoutSetup
     {
         // Load page TSconfig.
         if (($GLOBALS['TYPO3_REQUEST'] ?? null) && ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend()) {
-            $pageTSconfig = $GLOBALS['TSFE']->getPagesTSconfig();
+            $pageTSconfig = $GLOBALS['TYPO3_REQUEST']->getAttribute('frontend.controller')->getPagesTSconfig();
         } else {
             $pageTSconfig = BackendUtility::getPagesTSconfig($pageId);
         }


### PR DESCRIPTION
Instead use frontend.controller attribute which should be used according to https://docs.typo3.org/permalink/t3coreapi:tsfe-contentobjectrenderer

This fixes an issue we found in our configuration where in certain edge cases, for example when drag and dropping a content element. The global would be null whereas the Request Attribute is always set correctly.